### PR TITLE
Feat: Implementando modal prestador

### DIFF
--- a/src/main/resources/templates/historicoCliente.html
+++ b/src/main/resources/templates/historicoCliente.html
@@ -32,8 +32,8 @@
                     <tbody>
                     <tr th:each="agendamento : ${agendamentos}">
                         <td>
-                            <a href="#" data-bs-toggle="modal" th:data-bs-target="'#testeModal' + ${agendamento.id}">
-                                <span th:text="${agendamento.prestador.descricao}"></span>
+                            <a href="#" data-bs-toggle="modal" th:data-bs-target="'#prestadorModal' + ${agendamento.id}">
+                                <span th:text="${agendamento.prestador.nome}"></span>
                             </a>
                         </td>
                         <td th:text="${agendamento.servico.nome}"></td>
@@ -58,14 +58,32 @@
     </div>
 
     <div th:each="agendamento : ${agendamentos}">
-        <div class="modal fade" th:id="'testeModal' + ${agendamento?.id}" tabindex="-1" role="dialog" aria-labelledby="testeModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
+        <div class="modal fade" th:id="'prestadorModal' + ${agendamento?.id}" tabindex="-1" role="dialog" aria-labelledby="prestadorModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-lg" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="testeModalLabel">Detalhes do Prestador</h5>
                     </div>
                     <div class="modal-body">
-                        <strong th:text="${agendamento.servico.nome}"></strong>
+                        <table class="table w-100">
+                            <thead>
+                                <tr>
+                                    <th>Nome</th>
+                                    <th>E-mail</th>
+                                    <th>Descrição</th>
+                                    <th>Taxa de Cobrança</th>
+                                    <th>Endereço</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td th:text="${#strings.defaultString(agendamento.prestador.nome, 'Não informado')}"></td>
+                                    <td th:text="${#strings.defaultString(agendamento.prestador.email, 'Não informado')}"></td>
+                                    <td th:text="${#strings.defaultString(agendamento.prestador.descricao, 'Não informado')}"></td>
+                                    <td th:text="${#strings.defaultString(agendamento.prestador.taxaPorHora, 'Não informado')}"></td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Voltar</button>

--- a/src/main/resources/templates/historicoCliente.html
+++ b/src/main/resources/templates/historicoCliente.html
@@ -32,9 +32,7 @@
                     <tbody>
                     <tr th:each="agendamento : ${agendamentos}">
                         <td>
-                            <a class="prestador-name"
-                                  data-bs-toggle="modal"
-                                  th:data-bs-target="'#prestadorModal' + ${agendamento.id}">
+                            <a data-bs-toggle="modal" th:data-bs-target="'#prestadorModal' + ${agendamento.id}">
                                 <span th:text="${agendamento.prestador.nome}"></span>
                             </a>
                         </td>
@@ -60,8 +58,8 @@
     </div>
 
     <div th:each="agendamento : ${agendamentos}">
-        <div class="modal fade" th:id="'prestadorModal' + ${agendamento.id}" tabindex="-1" role="dialog" aria-labelledby="prestadorModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
+        <div class="modal fade" th:id="'prestadorModal' + ${agendamento?.id}" tabindex="-1" role="dialog" aria-labelledby="prestadorModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="prestadorModalLabel">Detalhes do Prestador</h5>
@@ -69,28 +67,26 @@
                     <div class="modal-body">
                         <table class="table">
                             <thead>
-                            <tr>
-                                <th>Nome</th>
-                                <th>E-mail</th>
-                                <th>Descrição</th>
-                                <th>Taxa de Cobrança</th>
-                                <th>Endereço</th>
-                            </tr>
+                                <tr>
+                                    <th>Nome</th>
+                                    <th>E-mail</th>
+                                    <th>Descrição</th>
+                                    <th>Taxa de Cobrança</th>
+                                    <th>Endereço</th>
+                                </tr>
                             </thead>
                             <tbody>
-                            <tr>
-                                <td th:text="${agendamento.prestador.nome}"></td>
-                                <td th:text="${agendamento.prestador.email}"></td>
-                                <td th:text="${agendamento.prestador.descricao}"></td>
-                                <td th:text="${agendamento.prestador.taxaPorHora}"></td>
-                                <td th:text="${agendamento.prestador.endereco}"></td>
-                            </tr>
+                                <tr>
+                                    <td th:text="${agendamento.prestador.nome}"></td>
+                                    <td th:text="${agendamento.prestador.email}"></td>
+                                    <td th:text="${agendamento.prestador.descricao}"></td>
+                                    <td th:text="${agendamento.prestador.taxaPorHora}"></td>
+                                    <td th:text="${agendamento.prestador.endereco}"></td>
+                                </tr>
                             </tbody>
                         </table>
                     </div>
-                    <input type="hidden" name="agendamentoId" th:value="${agendamento.id}">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Voltar</button>
-                    <button type="submit" class="btn btn-danger" data-bs-dismiss="modal">Cancelar</button>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/historicoCliente.html
+++ b/src/main/resources/templates/historicoCliente.html
@@ -31,7 +31,13 @@
                     </thead>
                     <tbody>
                     <tr th:each="agendamento : ${agendamentos}">
-                        <td th:text="${agendamento.prestador.nome}"></td>
+                        <td>
+                            <a class="prestador-name"
+                                  data-bs-toggle="modal"
+                                  th:data-bs-target="'#prestadorModal' + ${agendamento.id}">
+                                <span th:text="${agendamento.prestador.nome}"></span>
+                            </a>
+                        </td>
                         <td th:text="${agendamento.servico.nome}"></td>
                         <td th:text="${agendamento.data}"></td>
                         <td th:text="${agendamento.hora}"></td>
@@ -49,6 +55,43 @@
                     </tr>
                     </tbody>
                 </table>
+            </div>
+        </div>
+    </div>
+
+    <div th:each="agendamento : ${agendamentos}">
+        <div class="modal fade" th:id="'prestadorModal' + ${agendamento.id}" tabindex="-1" role="dialog" aria-labelledby="prestadorModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="prestadorModalLabel">Detalhes do Prestador</h5>
+                    </div>
+                    <div class="modal-body">
+                        <table class="table">
+                            <thead>
+                            <tr>
+                                <th>Nome</th>
+                                <th>E-mail</th>
+                                <th>Descrição</th>
+                                <th>Taxa de Cobrança</th>
+                                <th>Endereço</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td th:text="${agendamento.prestador.nome}"></td>
+                                <td th:text="${agendamento.prestador.email}"></td>
+                                <td th:text="${agendamento.prestador.descricao}"></td>
+                                <td th:text="${agendamento.prestador.taxaPorHora}"></td>
+                                <td th:text="${agendamento.prestador.endereco}"></td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <input type="hidden" name="agendamentoId" th:value="${agendamento.id}">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Voltar</button>
+                    <button type="submit" class="btn btn-danger" data-bs-dismiss="modal">Cancelar</button>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/historicoCliente.html
+++ b/src/main/resources/templates/historicoCliente.html
@@ -32,8 +32,8 @@
                     <tbody>
                     <tr th:each="agendamento : ${agendamentos}">
                         <td>
-                            <a data-bs-toggle="modal" th:data-bs-target="'#prestadorModal' + ${agendamento.id}">
-                                <span th:text="${agendamento.prestador.nome}"></span>
+                            <a href="#" data-bs-toggle="modal" th:data-bs-target="'#testeModal' + ${agendamento.id}">
+                                <span th:text="${agendamento.prestador.descricao}"></span>
                             </a>
                         </td>
                         <td th:text="${agendamento.servico.nome}"></td>
@@ -58,35 +58,18 @@
     </div>
 
     <div th:each="agendamento : ${agendamentos}">
-        <div class="modal fade" th:id="'prestadorModal' + ${agendamento?.id}" tabindex="-1" role="dialog" aria-labelledby="prestadorModalLabel" aria-hidden="true">
-            <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal fade" th:id="'testeModal' + ${agendamento?.id}" tabindex="-1" role="dialog" aria-labelledby="testeModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title" id="prestadorModalLabel">Detalhes do Prestador</h5>
+                        <h5 class="modal-title" id="testeModalLabel">Detalhes do Prestador</h5>
                     </div>
                     <div class="modal-body">
-                        <table class="table">
-                            <thead>
-                                <tr>
-                                    <th>Nome</th>
-                                    <th>E-mail</th>
-                                    <th>Descrição</th>
-                                    <th>Taxa de Cobrança</th>
-                                    <th>Endereço</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td th:text="${agendamento.prestador.nome}"></td>
-                                    <td th:text="${agendamento.prestador.email}"></td>
-                                    <td th:text="${agendamento.prestador.descricao}"></td>
-                                    <td th:text="${agendamento.prestador.taxaPorHora}"></td>
-                                    <td th:text="${agendamento.prestador.endereco}"></td>
-                                </tr>
-                            </tbody>
-                        </table>
+                        <strong th:text="${agendamento.servico.nome}"></strong>
                     </div>
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Voltar</button>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Voltar</button>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Implementado modal com detalhes de informações do prestador, quando é clicado no nome do prestador.

OBS: a propriedade "endereco" no objeto não está sendo preenchida e deve ser resolvido em outra tarefa, mas já deixei incluso no thead da tabela.

![image](https://github.com/meirellesh/goservice/assets/128240736/0e3ee40e-5741-4c93-821a-e3e5d2832f0e)
![image](https://github.com/meirellesh/goservice/assets/128240736/9956e20e-2015-4935-b0c3-52cdf38bc900)
